### PR TITLE
Update declaration of AuctionBucketKey

### DIFF
--- a/src/server/game/Server/Packets/AuctionHousePackets.h
+++ b/src/server/game/Server/Packets/AuctionHousePackets.h
@@ -118,7 +118,7 @@ namespace WorldPackets
             Optional<ObjectGuid> Bidder;
             Optional<uint64> BidAmount;
             std::vector<Item::ItemGemData> Gems;
-            Optional<AuctionBucketKey> AuctionBucketKey;
+            Optional<WorldPackets::AuctionHouse::AuctionBucketKey> AuctionBucketKey;
         };
 
         struct AuctionBidderNotification


### PR DESCRIPTION
Resolves linux (ubuntu in my case) compilation error:
/home/trinity/TrinityCore-master/src/server/game/Server/Packets/AuctionHousePackets.h:121:40: error: declaration of ‘Optional<WorldPackets::AuctionHouse::AuctionBucketKey> WorldPackets::AuctionHouse::AuctionItem::AuctionBucketKey’ [-fpermissive]
             Optional<AuctionBucketKey> AuctionBucketKey;
                                        ^~~~~~~~~~~~~~~~
/home/trinity/TrinityCore-master/src/server/game/Server/Packets/AuctionHousePackets.h:35:16: error: changes meaning of ‘AuctionBucketKey’ from ‘struct WorldPackets::AuctionHouse::AuctionBucketKey’ [-fpermissive]
         struct AuctionBucketKey
                ^~~~~~~~~~~~~~~~

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Small change to field declaration to satisfy compiler
-  
-  

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [X] master

**Issues addressed:** Closes #  (insert issue tracker number)
24381

**Tests performed:** (Does it build, tested in-game, etc.)
Compiles and links

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
